### PR TITLE
【新增/修复】

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_zh.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_zh.yml
@@ -1,6 +1,7 @@
 name: 错误反馈
 description: '提交 LINUX DO WIKI 漏洞'
 title: '[错误] '
+labels: ["【错误】"]
 body:
   - type: checkboxes
     id: ensure

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: LINUX DO WIKI本站
+    url: https://wiki.linux.do
+    about: 在 上报错误/请求功能 前，您可以进一步确认是否存在这一 错误/功能

--- a/.github/ISSUE_TEMPLATE/feature_request_zh.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_zh.yml
@@ -1,6 +1,7 @@
 name: 功能请求
 description: '请求 LINUX DO WIKI 功能'
 title: '[建议] '
+labels: ["【建议】"]
 body:
   - type: checkboxes
     id: ensure

--- a/content/Encyclopedia/User/_meta.ts
+++ b/content/Encyclopedia/User/_meta.ts
@@ -2,4 +2,5 @@ export default {
     user3: "Zhiyang",
     vux1jpmal5t41lg: "vv佬",
     '6512345': "65",
+    handsome: "大帅哥"
 }

--- a/content/Encyclopedia/User/handsome.mdx
+++ b/content/Encyclopedia/User/handsome.mdx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+import { UserHoverCard } from '@/components/common/UserHoverCard'
+import { TopicHoverCard } from '@/components/common/TopicHoverCard'
+
+## 大帅哥
+
+指的是 **<UserHoverCard username='handsome'/>**，因为其能与**<UserHoverCard username='neo'/>**在[排行榜](https://linux.do/leaderboard)中角逐第三名和他几乎秒回贴的特性而闻名，~~江湖~~L站人称`大氵哥`，即`大帅哥很能水`的意思
+
+## 相关探索
+
+- <TopicHoverCard topicId='266833' defaultTitle='关于大帅哥的主人这件事' />
+
+其他帖子也基本能看见大帅哥的身影


### PR DESCRIPTION
## Tags增加

### 文件位置

`/.github/ISSUE_TEMPLATE/` 下` bug_report_zh.yml` 和 `feature_request_zh.yml`

### 作用/增加原因

当从默认模板创捷Issue时，默认增加以下标签，节省额外增加标签的时间：

- 【错误】
- 【建议】

## 配置文件

### 文件位置

`/.github/ISSUE_TEMPLATE/config.yml`

### 作用/增加原因

完善Issue模板

## 增加 `大帅哥` 相关内容

### 文件位置

`/content/Encyclopedia/User/handsome.mdx`

### 作用/增加原因

扩充名人堂

## 社区个人主页

https://linux.do/u/mr_onion